### PR TITLE
[What] u32 [5]能正確篩選Solo & Mini2的機種，將Filter中的Raid 0,1,5,10拆成兩部分 - UI拆成…

### DIFF
--- a/products/Crystal CT-4000/Crystal CT-4000.json
+++ b/products/Crystal CT-4000/Crystal CT-4000.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Tower",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Crystal CT-4000R/Crystal CT-4000R.json
+++ b/products/Crystal CT-4000R/Crystal CT-4000R.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Rackmount",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Crystal CT-8000R/Crystal CT-8000R.json
+++ b/products/Crystal CT-8000R/Crystal CT-8000R.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Rackmount",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Crystal CT-8000RP/Crystal CT-8000RP.json
+++ b/products/Crystal CT-8000RP/Crystal CT-8000RP.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Rackmount",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": true,
         "signal_input": false
     },

--- a/products/Mainconsole CT-8000IP/Mainconsole CT-8000IP.json
+++ b/products/Mainconsole CT-8000IP/Mainconsole CT-8000IP.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": true,
         "hardware_type": "Rackmount",
-        "raid": false,
+        "raid_0_1": false,
+        "raid_5_10": false,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Mainconsole IP+/Mainconsole IP+.json
+++ b/products/Mainconsole IP+/Mainconsole IP+.json
@@ -13,7 +13,8 @@
         "local_display": true,
         "local_config": true,
         "hardware_type": "",
-        "raid": false,
+        "raid_0_1": false,
+        "raid_5_10": false,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Mainconsole NH-4500/Mainconsole NH-4500.json
+++ b/products/Mainconsole NH-4500/Mainconsole NH-4500.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": true,
         "hardware_type": "Rackmount",
-        "raid": false,
+        "raid_0_1": false,
+        "raid_5_10": false,
         "power_supply": true,
         "signal_input": true
     },

--- a/products/Mini2 NE-2020 2040/Mini2 NE-2020 2040.json
+++ b/products/Mini2 NE-2020 2040/Mini2 NE-2020 2040.json
@@ -17,7 +17,8 @@
         "local_display": false,
         "local_config": false,
         "hardware_type": "Tower",
-        "raid": false,
+        "raid_0_1": true,
+        "raid_5_10": false,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Mini2 NE-4080 4160/Mini2 NE-4080 4160.json
+++ b/products/Mini2 NE-4080 4160/Mini2 NE-4080 4160.json
@@ -17,7 +17,8 @@
         "local_display": false,
         "local_config": false,
         "hardware_type": "Tower",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Solo NS-2040 2080 2160/Solo NS-2040 2080 2160.json
+++ b/products/Solo NS-2040 2080 2160/Solo NS-2040 2080 2160.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": true,
         "hardware_type": "Tower",
-        "raid": false,
+        "raid_0_1": true,
+        "raid_5_10": false,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Solo NS-8060 8160/Solo NS-8060 8160.json
+++ b/products/Solo NS-8060 8160/Solo NS-8060 8160.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": true,
         "hardware_type": "Rackmount",
-        "raid": false,
+        "raid_0_1": true,
+        "raid_5_10": false,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Solo NS-8065 8165/Solo NS-8065 8165.json
+++ b/products/Solo NS-8065 8165/Solo NS-8065 8165.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": true,
         "hardware_type": "Rackmount",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Titan NT-4040/Titan NT-4040.json
+++ b/products/Titan NT-4040/Titan NT-4040.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Tower",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Titan NT-4040R/Titan NT-4040R.json
+++ b/products/Titan NT-4040R/Titan NT-4040R.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Rackmount",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Titan NT-8040R/Titan NT-8040R.json
+++ b/products/Titan NT-8040R/Titan NT-8040R.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Rackmount",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": false,
         "signal_input": false
     },

--- a/products/Titan NT-8040RP/Titan NT-8040RP.json
+++ b/products/Titan NT-8040RP/Titan NT-8040RP.json
@@ -17,7 +17,8 @@
         "local_display": true,
         "local_config": false,
         "hardware_type": "Rackmount",
-        "raid": true,
+        "raid_0_1": true,
+        "raid_5_10": true,
         "power_supply": true,
         "signal_input": false
     },


### PR DESCRIPTION
…[0, 1] [5, 10] & RAID　match logic

[Why] User story
[How] 1. Changed the raid property of all products
[Reviewer] Yoyo
